### PR TITLE
Maintain heading levels defined through mkdocs.yml

### DIFF
--- a/mkdocs_pandoc/plugin.py
+++ b/mkdocs_pandoc/plugin.py
@@ -56,14 +56,21 @@ class PandocPlugin(BasePlugin):
         )
 
     def on_nav(self, nav, config, files):
-        if not self.enabled:
-            return nav
-
-        self.renderer.pages = [None] * len(nav.pages)
-        for page in nav.pages:
-            self.renderer.page_order.append(page.file.src_path)
-
+        # We collect recursively all navigation levels provided by the mkdocs configuration
+        self.collect_nav(nav, 1)
         return nav
+
+    def collect_nav(self, nav, level: int):
+        if nav is None:
+            return 
+
+        for child in nav:
+            if hasattr(child, "file"):
+                self.renderer.add_section(level, str(child.title), child.file.src_path)
+            else:
+                self.renderer.add_section(level, str(child.title), "")
+
+            self.collect_nav(child.children, level + 1)
 
     def on_post_page(self, output_content, page, config):
         if not self.enabled:

--- a/mkdocs_pandoc/plugin.py
+++ b/mkdocs_pandoc/plugin.py
@@ -56,8 +56,10 @@ class PandocPlugin(BasePlugin):
         )
 
     def on_nav(self, nav, config, files):
-        # We collect recursively all navigation levels provided by the mkdocs configuration
-        self.collect_nav(nav, 1)
+        if self.enabled:
+            # We collect recursively all navigation levels provided by the mkdocs configuration
+            self.collect_nav(nav, 1)
+            
         return nav
 
     def collect_nav(self, nav, level: int):


### PR DESCRIPTION
While testing your plugin, I came across the following problem:

If a mkdocs.yml file specifies a navigation structure with "empty" levels (as shown below), the structure is not maintained in the resulting PDF document.
```yml
nav:
  - Report Summary: summary.md
  - Weekly reports:
    - 2024:
      - September:
        - 2024.09.01: reports/2024.09.01.md
        - 2024.09.08: reports/2024.09.08.md
```

The expected behavior would be to have a chapter structure as follows:
```
Report Summary
Weekly reports
+- 2024
   +- September
      +- 2024.09.01
         +- <section structures as defined in the md-file>
      +- 2024.09.08
         +- <section structures as defined in the md-file>
```

However, the combined document uses the unmodified heading levels from each source document. As a result, the document's structure becomes inconsistent:
```
Report Summary
Weekly reports
2024.09.01
+- <section structures as defined in the md-file>
2024.09.08
+- <section structures as defined in the md-file>
```

This pull request provides a potential solution by altering the combining process in such a way, that the headings of the source files are aligned to their actual position in the structure of the document, based on the `nav` section of the configuration file. This is achieved by adding sufficient `#`-characters to the headings.

I've tested this proposal on my machine and it seems to solve the case outlined above. However, Python not being my primary programming language and me being even less familiar with `MkDocs` object model. it's defeinitely worth taking a closer look at the implementation and its impact. I'm pretty sure there is still room for improvement. Maybe its even worth considering to have this behaviour configurable.

I'm looking forward for your feedback, @alexandre-perrin .